### PR TITLE
Record Browser UI improvements

### DIFF
--- a/CreationEditor.GUI/Views/Record/RecordBrowser.xaml
+++ b/CreationEditor.GUI/Views/Record/RecordBrowser.xaml
@@ -1,49 +1,61 @@
-﻿<record:RecordBrowserViewBase x:Class="CreationEditor.GUI.Views.Record.RecordBrowser"
-                              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-                              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                              xmlns:recordModel="clr-namespace:CreationEditor.GUI.ViewModels.Record"
-                              xmlns:record="clr-namespace:CreationEditor.GUI.Views.Record"
-                              xmlns:recordBrowser="clr-namespace:CreationEditor.GUI.Models.Record.Browser"
-                              mc:Ignorable="d" d:DataContext="{d:DesignInstance recordModel:IRecordBrowserVM}"
-                              d:DesignHeight="720" d:DesignWidth="480">
+﻿<record:RecordBrowserViewBase
+    x:Class="CreationEditor.GUI.Views.Record.RecordBrowser"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:record="clr-namespace:CreationEditor.GUI.Views.Record"
+    xmlns:recordBrowser="clr-namespace:CreationEditor.GUI.Models.Record.Browser"
+    xmlns:recordModel="clr-namespace:CreationEditor.GUI.ViewModels.Record"
+    d:DataContext="{d:DesignInstance recordModel:IRecordBrowserVM}"
+    d:DesignHeight="720"
+    d:DesignWidth="480"
+    mc:Ignorable="d">
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="Auto" />
-            <ColumnDefinition Width="5" />
-            <ColumnDefinition Width="Auto" />
+            <ColumnDefinition MinWidth="5" MaxWidth="5" />
+            <ColumnDefinition Width="*" />
         </Grid.ColumnDefinitions>
 
         <Grid Grid.Column="0">
-            <StackPanel>
-                <StackPanel Margin="5">
-                    <TextBlock Text="Filter" />
-                    <TextBox Text="{Binding RecordBrowserSettings.SearchTerm, UpdateSourceTrigger=PropertyChanged}" />
-                </StackPanel>
-                <CheckBox Margin="5"
-                          Content="Show Only Active"
-                          IsChecked="{Binding RecordBrowserSettings.OnlyActive}" />
-                <TreeView ItemsSource="{Binding RecordTypeGroups}">
-                    <TreeView.Resources>
-                        <HierarchicalDataTemplate DataType="{x:Type recordBrowser:RecordTypeGroup}"
-                                                  ItemsSource="{Binding RecordTypes}">
-                            <TextBlock Text="{Binding GroupName}" />
-                        </HierarchicalDataTemplate>
-                        <DataTemplate DataType="{x:Type recordBrowser:RecordTypeListing}">
-                            <Button
-                                Command="{Binding DataContext.SelectRecordType, RelativeSource={RelativeSource AncestorType=record:RecordBrowser}}"
-                                CommandParameter="{Binding}">
-                                <TextBlock Text="{Binding RecordTypeName}" />
-                            </Button>
-                        </DataTemplate>
-                    </TreeView.Resources>
-                </TreeView>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+
+            <StackPanel Grid.Row="0" Margin="5">
+                <TextBlock Text="Filter" />
+                <TextBox Padding="1" Text="{Binding RecordBrowserSettings.SearchTerm, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
+            <CheckBox
+                Grid.Row="1"
+                Margin="5"
+                Content="Show Only Active"
+                IsChecked="{Binding RecordBrowserSettings.OnlyActive}" />
+            <TreeView Grid.Row="2" ItemsSource="{Binding RecordTypeGroups}">
+                <TreeView.Resources>
+                    <HierarchicalDataTemplate DataType="{x:Type recordBrowser:RecordTypeGroup}" ItemsSource="{Binding RecordTypes}">
+                        <TextBlock Text="{Binding GroupName}" />
+                    </HierarchicalDataTemplate>
+                    <DataTemplate DataType="{x:Type recordBrowser:RecordTypeListing}">
+                        <Button Command="{Binding DataContext.SelectRecordType, RelativeSource={RelativeSource AncestorType=record:RecordBrowser}}" CommandParameter="{Binding}">
+                            <TextBlock Text="{Binding RecordTypeName}" />
+                        </Button>
+                    </DataTemplate>
+                </TreeView.Resources>
+            </TreeView>
         </Grid>
 
-        <GridSplitter Grid.Column="1" Width="5" />
+        <GridSplitter
+            Grid.Column="1"
+            Width="5"
+            HorizontalAlignment="Stretch" />
 
-        <ContentControl Grid.Column="2" Content="{Binding RecordList}" />
+        <ContentControl
+            Grid.Column="2"
+            HorizontalAlignment="Stretch"
+            Content="{Binding RecordList}" />
     </Grid>
 </record:RecordBrowserViewBase>

--- a/CreationEditor.GUI/Views/Record/RecordList.xaml
+++ b/CreationEditor.GUI/Views/Record/RecordList.xaml
@@ -38,11 +38,14 @@
                             </syncfusion:SfDataGrid.ContextMenu>
                             <syncfusion:SfDataGrid.Columns>
                                 <syncfusion:GridTextColumn HeaderText="EditorID" MappingName="Record.EditorID"
-                                                           AllowFiltering="True" AllowSorting="True" />
+                                                           AllowFiltering="True" AllowSorting="True"
+                                                           ColumnSizer="Star" />
                                 <syncfusion:GridTextColumn HeaderText="FormKey" MappingName="Record.FormKey"
-                                                           AllowFiltering="True" AllowSorting="True" />
+                                                           AllowFiltering="True" AllowSorting="True" 
+                                                           ColumnSizer="Star" />
                                 <syncfusion:GridTextColumn HeaderText="Use Info" MappingName="References.Count"
-                                                           AllowFiltering="True" AllowSorting="True" />
+                                                           AllowFiltering="True" AllowSorting="True"
+                                                           ColumnSizer="Star" />
                             </syncfusion:SfDataGrid.Columns>
                         </syncfusion:SfDataGrid>
 


### PR DESCRIPTION
This PR adds a few QOL improvements to the Record Browser UI:  
- Made the left-side `TreeView` control scrollable when its contents go off-screen *(both horizontally & vertically, as-needed)*
- Made both the left-side & right-side panels fit the available space afforded to them by the `GridSplitter`

![ui-improvements-example](https://user-images.githubusercontent.com/1927798/198712331-59c98012-e311-469a-95a1-90d5ea3f3273.gif)  
